### PR TITLE
Iterate overall config

### DIFF
--- a/.saturn/saturn.json
+++ b/.saturn/saturn.json
@@ -8,7 +8,7 @@
   "description": "",
   "environment_variables": {},
   "working_directory": "/home/jovyan/workspace/lamindb/docs/guide",
-  "start_script": "mamba install -n base -c conda-forge ipylab ipytree bqplot ipywidgets numpy\nmamba install -n saturn -c conda-forge ipylab ipytree bqplot ipywidgets numpy\n\n/opt/saturncloud/envs/saturn/bin/pip install nbproject\n/opt/saturncloud/bin/pip install nbproject lamindb\n",
+  "start_script": "mamba install -n base -c conda-forge ipylab ipytree bqplot ipywidgets numpy\nmamba install -n saturn -c conda-forge ipylab ipytree bqplot ipywidgets numpy\n\n/opt/saturncloud/envs/saturn/bin/pip install nbproject\n/opt/saturncloud/envs/saturn/bin/pip install nbproject lamindb\n",
   "git_repositories": [
     {
       "url": "git@github.com:laminlabs/lamindb.git",

--- a/.saturn/saturn.json
+++ b/.saturn/saturn.json
@@ -1,5 +1,5 @@
 {
-  "name": "lamin-labs",
+  "name": "lamin",
   "image": {
     "name": "saturn-python",
     "version": "2022.06.01",

--- a/.saturn/saturn.json
+++ b/.saturn/saturn.json
@@ -8,7 +8,7 @@
   "description": "",
   "environment_variables": {},
   "working_directory": "/home/jovyan/workspace/lamindb/docs/guide",
-  "start_script": "mamba install -n base -c conda-forge ipylab ipytree bqplot ipywidgets numpy\nmamba install -n saturn -c conda-forge ipylab ipytree bqplot ipywidgets numpy\n\n/opt/saturncloud/envs/saturn/bin/pip install nbproject\n/opt/saturncloud/envs/saturn/bin/pip install nbproject lamindb\n",
+  "start_script": "mamba install -n base -c conda-forge ipylab ipytree bqplot ipywidgets numpy\nmamba install -n saturn -c conda-forge ipylab ipytree bqplot ipywidgets numpy\n/opt/saturncloud/envs/saturn/bin/pip install lamindb\n",
   "git_repositories": [
     {
       "url": "git@github.com:laminlabs/lamindb.git",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Lamin Labs in Saturn Cloud
+# Run Lamin on Saturn Cloud
+
+Manage biological data & analyses using Lamin.
 
 <a href="https://app.community.saturnenterprise.io/dash/resources?recipeUrl=https://raw.githubusercontent.com/saturncloud/lamin-ai-example/main/.saturn/saturn.json" target="_blank" rel="noopener">
   <img src="https://saturncloud.io/images/embed/run-in-saturn-cloud.svg" alt="Run in Saturn Cloud"/>


### PR DESCRIPTION
- lamindb itself wasn’t available in the env: https://github.com/laminlabs/lamin-ai-example/commit/81804938cbd20d866809978bca693f325197d0e5
- The nbproject install can be dropped as it’s a dependency of lamindb: https://github.com/laminlabs/lamin-ai-example/commit/1559458616e23d1273cdf47d9bc175b1ed8d0bda
- We typically brand as “Lamin”, not as “Lamin Labs”: https://github.com/laminlabs/lamin-ai-example/commit/f7f251f2c6c3b275421fbc477ea533253b83a36f
- I added a subtitle, which you could use for the tile: https://github.com/laminlabs/lamin-ai-example/commit/32d18cf3beae326b73e7fe76a5a21dea75a6318c